### PR TITLE
Fixed issue where text that starts with number can conflict with font size

### DIFF
--- a/src/textFormatBuilder.test.ts
+++ b/src/textFormatBuilder.test.ts
@@ -78,7 +78,7 @@ describe("TextFormatBuilder", () => {
     test("Should set the font size", () => {
         const builder = new TextFormatBuilder();
         const actual = builder.fontSize(12).value;
-        expect(actual).toBe("&12");
+        expect(actual).toBe("&12 ");
     });
 
     test("Should throw error when fontSize is negative number", () => {

--- a/src/textFormatBuilder.ts
+++ b/src/textFormatBuilder.ts
@@ -104,7 +104,7 @@ export class TextFormatBuilder {
             throw new TextFormatBuilderError("Fontsize must be less than 100");
         }
 
-        this.#format += `&${fontSize}`;
+        this.#format += `&${fontSize} `;
         return this;
     }
 


### PR DESCRIPTION
Add a space after font size this prevent any text that starts with numbers being included within the font size